### PR TITLE
Restore support for mercurial<4.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ first time.
 System Requirements
 -------------------
 
-This project depends on Python 2.7 and the Mercurial 4.6 package. If
-Python is not installed, install it before proceeding. The Mercurial
-package can be installed with `pip install mercurial`.
+This project depends on Python 2.7 and the Mercurial package. If Python
+is not installed, install it before proceeding. The Mercurial package
+can be installed with `pip install mercurial`.
 
 If you're on Windows, run the following commands in git bash (Git for
 Windows).

--- a/hg-fast-export.py
+++ b/hg-fast-export.py
@@ -4,7 +4,13 @@
 # License: MIT <http://www.opensource.org/licenses/mit-license.php>
 
 from mercurial import node
-from mercurial.scmutil import revsymbol
+try:
+  from mercurial.scmutil import revsymbol
+  HG46 = True
+except ImportError:
+  def revsymbol(repo,revision):
+    return repo.changectx(revision)
+  HG46 = False
 from hg2git import setup_repo,fixup_user,get_branch,get_changeset
 from hg2git import load_cache,save_cache,get_git_sha1,set_default_branch,set_origin_name
 from optparse import OptionParser
@@ -239,7 +245,7 @@ def export_commit(ui,repo,revision,old_marks,max,count,authors,
       # later non-merge revision: feed in changed manifest
       # if we have exactly one parent, just take the changes from the
       # manifest without expensively comparing checksums
-      f=repo.status(parents[0],revnode)[:3]
+      f=repo.status(parents[0] if HG46 else repo.lookup(parents[0]),revnode)[:3]
       added,changed,removed=f[1],f[0],f[2]
       type='simple delta'
     else: # a merge with two parents

--- a/hg2git.py
+++ b/hg2git.py
@@ -4,8 +4,12 @@
 # License: MIT <http://www.opensource.org/licenses/mit-license.php>
 
 from mercurial import hg,util,ui,templatefilters
-from mercurial import error as hgerror
-from mercurial.scmutil import revsymbol,binnode
+try:
+  from mercurial import error as hgerror
+  from mercurial.scmutil import revsymbol,binnode
+  HG46 = True
+except ImportError:
+  HG46 = False
 
 import re
 import os
@@ -72,15 +76,18 @@ def get_branch(name):
   return name
 
 def get_changeset(ui,repo,revision,authors={},encoding=''):
-  # Starting with Mercurial 4.6 lookup no longer accepts raw hashes
-  # for lookups. Work around it by changing our behaviour depending on
-  # how it fails
-  try:
+  if HG46:
+    # Starting with Mercurial 4.6 lookup no longer accepts raw hashes
+    # for lookups. Work around it by changing our behaviour depending on
+    # how it fails
+    try:
+      node=repo.lookup(revision)
+    except hgerror.ProgrammingError:
+      node=binnode(revsymbol(repo,str(revision))) # We were given a numeric rev
+    except hgerror.RepoLookupError:
+      node=revision # We got a raw hash
+  else:
     node=repo.lookup(revision)
-  except hgerror.ProgrammingError:
-    node=binnode(revsymbol(repo,str(revision))) # We were given a numeric rev
-  except hgerror.RepoLookupError:
-    node=revision # We got a raw hash
   (manifest,user,(time,timezone),files,desc,extra)=repo.changelog.read(node)
   if encoding:
     user=user.decode(encoding).encode('utf8')


### PR DESCRIPTION
e200cec39fac8a8ebb1c7d7690c00d5cb15f0c30 broke mercurial<4.6 support,
which was a Bad Thing. Linuxy types particularly are used to being able
to use the mercurial package from their OS package manager, rather than
needing to mess around with installing extra packages from pip (which is
normally a disaster if you’re not a Python programmer and used to
messing around with virtualenvs or similar), and almost none of those
have Mercurial 4.6 yet. (Ubuntu, for example, is on 4.5.3 in 18.04 LTS,
and 3.7.3 in 16.04 LTS. So probably having 4.6 or later is about two and
a half to four years off!)

The differences in Mercurial 4.6 are small enough that restoring support
is not difficult, and it makes it work for everyone, so it’s worth
doing.

Fixes #132.